### PR TITLE
Improve error messaging for empty text columns

### DIFF
--- a/src/decision_ai/features/engineer.py
+++ b/src/decision_ai/features/engineer.py
@@ -218,6 +218,13 @@ class FeatureEngineer:
         ]
         num_default = ["informacoes_profissionais__remuneracao"]
 
+        # Validate that we actually have some text data to vectorize
+        for text_col in ["job_text", "cv_text"]:
+            if text_col in df.columns and df[text_col].astype(str).str.strip().eq("").all():
+                raise ValueError(
+                    f"Coluna {text_col} vazia: verifique se os dados foram ingeridos corretamente"
+                )
+
         cat_cols = [c for c in cat_default if c in df.columns]
         num_cols = [c for c in num_default if c in df.columns]
 

--- a/tests/unit/test_engineer.py
+++ b/tests/unit/test_engineer.py
@@ -1,0 +1,16 @@
+import pandas as pd
+import pytest
+
+from decision_ai.features.engineer import FeatureEngineer
+
+
+def test_fit_transform_raises_on_empty_text():
+    """FeatureEngineer.fit_transform should fail when text columns are empty."""
+    df = pd.DataFrame({
+        "job_text": ["", ""],
+        "cv_text": ["", ""],
+    })
+
+    fe = FeatureEngineer()
+    with pytest.raises(ValueError, match="Coluna job_text vazia"):
+        fe.fit_transform(df)


### PR DESCRIPTION
## Summary
- check for empty `job_text` or `cv_text` before building feature pipeline
- add unit test covering this validation

## Testing
- `python3 -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest')*

------
https://chatgpt.com/codex/tasks/task_e_687e72732f7c83339e36a344bf616ec5