### PR TITLE
Check for missing job description fields

### DIFF
--- a/tests/unit/test_engineer.py
+++ b/tests/unit/test_engineer.py
@@ -14,3 +14,46 @@ def test_fit_transform_raises_on_empty_text():
     fe = FeatureEngineer()
     with pytest.raises(ValueError, match="Coluna job_text vazia"):
         fe.fit_transform(df)
+
+
+def test_build_dataframe_uses_fallback(monkeypatch):
+    """Fallback fields should be used when job description columns are missing."""
+    dim_app = pd.DataFrame({"applicant_id": ["1"]})
+    dim_job = pd.DataFrame({
+        "job_id": ["1"],
+        "informacoes_basicas__titulo_vaga": ["Dev"],
+    })
+    fact = pd.DataFrame({
+        "applicant_id": ["1"],
+        "job_id": ["1"],
+        "status": ["Contratado"],
+    })
+
+    monkeypatch.setattr(
+        "decision_ai.features.engineer._load_tables",
+        lambda: (dim_app, dim_job, fact),
+    )
+
+    fe = FeatureEngineer()
+    df = fe.build_dataframe()
+    assert df.loc[0, "job_text"] == "Dev"
+
+
+def test_build_dataframe_raises_when_no_description(monkeypatch):
+    """Clear error when required job description columns are absent."""
+    dim_app = pd.DataFrame({"applicant_id": ["1"]})
+    dim_job = pd.DataFrame({"job_id": ["1"]})
+    fact = pd.DataFrame({
+        "applicant_id": ["1"],
+        "job_id": ["1"],
+        "status": ["Encaminhado"],
+    })
+
+    monkeypatch.setattr(
+        "decision_ai.features.engineer._load_tables",
+        lambda: (dim_app, dim_job, fact),
+    )
+
+    fe = FeatureEngineer()
+    with pytest.raises(ValueError, match="Nenhuma coluna de descricao de vaga"):
+        fe.build_dataframe()


### PR DESCRIPTION
## Summary
- validate presence of job description columns in `build_dataframe`
- provide fallback using job title
- test missing description handling

## Testing
- `PYENV_VERSION=3.11.12 python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas pytest` *(fails: externally-managed-environment)*

------
https://chatgpt.com/codex/tasks/task_e_687e777a531c8333880f7156d0facdf7